### PR TITLE
fix gcc implicit declaration warning

### DIFF
--- a/raspi-gpio.c
+++ b/raspi-gpio.c
@@ -14,6 +14,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <sys/mman.h>
+#include <time.h>
 
 char *gpio_alt_names[54*6] =
 {


### PR DESCRIPTION
Building raspi-gpio from git with gcc 6.3.1 produces the following warning:
```
raspi-gpio.c:162:5: warning: implicit declaration of function ‘nanosleep’ [-Wimplicit-function-declaration]
     nanosleep(&tv_req, &tv_rem);
```

The fix is rather trivial - add 
#include <time.h>
to raspi-gpio.c